### PR TITLE
Fix - send all key-pair details

### DIFF
--- a/con_opstk/data_handler/api_server.py
+++ b/con_opstk/data_handler/api_server.py
@@ -156,7 +156,7 @@ def create_keypair():
 
         app.logger.debug(f"Successfully submitted create key pair request")
 
-        resp = {"success": True, "private_key": result['private_key']}
+        resp = {"success": True, "key_pair": result}
         return jsonify(resp), 202
     except APIServerDefError as e:
         response = {"error": type(e).__name__, "message": str(e)}


### PR DESCRIPTION
Send all key-pair details in the create key-pairs response, instead of just the private key.