### PR TITLE
Support specifying docker image build labels

### DIFF
--- a/Dockerfiles/Dockerfile.api_server
+++ b/Dockerfiles/Dockerfile.api_server
@@ -1,6 +1,15 @@
 # Use an official Python runtime as a parent image
 FROM python:3.8-slim-buster
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Concertim Openstack API Server"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 # Copy the directory contents into the container at /app

--- a/Dockerfiles/Dockerfile.billing
+++ b/Dockerfiles/Dockerfile.billing
@@ -1,6 +1,15 @@
 # Use an official Python runtime as a parent image
 FROM python:3.8-slim-buster
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Concertim Openstack Billing"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 # Copy the directory contents into the container at /app

--- a/Dockerfiles/Dockerfile.metrics
+++ b/Dockerfiles/Dockerfile.metrics
@@ -1,6 +1,15 @@
 # Use an official Python runtime as a parent image
 FROM python:3.8-slim-buster
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Concertim Openstack Metrics"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 # Copy the directory contents into the container at /app

--- a/Dockerfiles/Dockerfile.updates_bulk
+++ b/Dockerfiles/Dockerfile.updates_bulk
@@ -1,6 +1,15 @@
 # Use an official Python runtime as a parent image
 FROM python:3.8-slim-buster
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Concertim Openstack Bulk Updates"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 # Copy the directory contents into the container at /app

--- a/Dockerfiles/Dockerfile.updates_mq
+++ b/Dockerfiles/Dockerfile.updates_mq
@@ -1,6 +1,15 @@
 # Use an official Python runtime as a parent image
 FROM python:3.8-slim-buster
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG BUILD_REVISION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.revision=$BUILD_REVISION
+LABEL org.opencontainers.image.title="Concertim Openstack MQ Listener"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 # Copy the directory contents into the container at /app


### PR DESCRIPTION
The all-in-one ansible playbook will attempt to add build labels to the docker images it builds.  To do so the Dockerfiles need to support that.  This PR adds that support.  The format used for the labels is that given in https://specs.opencontainers.org/image-spec/annotations/?v=v1.0.1.

Refs https://github.com/alces-flight/concertim-ansible-playbook/pull/69.