### PR TITLE
Fix various issues

### DIFF
--- a/con_opstk/concertim/concertim.py
+++ b/con_opstk/concertim/concertim.py
@@ -17,8 +17,8 @@ class ConcertimService(object):
         self._LOG_FILE = log_file
         self.__LOGGER = create_logger(__name__, self._LOG_FILE, self._CONFIG['log_level'])
         self._URL = self._CONFIG['concertim']['concertim_url']
-        self.__AUTH_TOKEN = self.__get_auth_token()
         self.__retry_count = 0
+        self.__AUTH_TOKEN = self.__get_auth_token()
     
     def __get_auth_token(self):
         login = self._CONFIG['concertim']['concertim_username']

--- a/docs/killbill_ref.md
+++ b/docs/killbill_ref.md
@@ -31,7 +31,7 @@ The Concertim-Openstack package communicates with Killbill via the [Killbill API
 
 ## KillBill Configuration
 
-In order for the KillBill environment to work with the Concertim-Openstack Service you need to [create the catalog](https://docs.killbill.io/latest/catalog-examples.html) for the clusters built in Concertim to be track by. In our [example catalog](/openstack_billing/billingplatforms/killbill/catalog.xml) we setup a basic configuration for a billing model with 2 metrics being track for their individual contributuons to the invoice: `openstack-billed-instance` and `openstack-billed-vcpus`.
+In order for the KillBill environment to work with the Concertim-Openstack Service you need to [create the catalog](https://docs.killbill.io/latest/catalog-examples.html) for the clusters built in Concertim to be track by. In our [example catalog](/con_opstk/billing/killbill/catalog.xml) we setup a basic configuration for a billing model with 2 metrics being track for their individual contributuons to the invoice: `openstack-billed-instance` and `openstack-billed-vcpus`.
 
 - `openstack-billed-instance` - the amount to be billed for instance uptime
 - `openstack-billed-vcpus` - the amount to be billed for the amount of vcpus the instance is occupying

--- a/etc/config-sample.yaml
+++ b/etc/config-sample.yaml
@@ -15,7 +15,7 @@ rmq:
     rmq_path : "/"
 concertim:
     concertim_url: "https://host.concertim"
-    concertim_username: "admin "
+    concertim_username: "admin"
     concertim_password: "password"
     default_rack_height: 20
 killbill:


### PR DESCRIPTION
Fix some minor issues I encountered during the killbill automated deploy work.

* Set `__retry_count` prior to getting auth token. Getting the token may need to retry if it does we need `__retry_count` to have already been set.
* Remove trailing space from example config file's concertim admin user name: `admin` not `admin `.
* Fix link to killbill example catalog.