### PR TITLE
Misc fixes for issues found whilst testing the visualiser change from integer IDs to UUIDs.

### DIFF
--- a/con_opstk/data_handler/api_server.py
+++ b/con_opstk/data_handler/api_server.py
@@ -391,7 +391,7 @@ def get_draft_invoice():
 
         response = api_handler.get_draft_invoice(req_data['invoice']['billing_account_id'])
 
-        resp = {"invoice_html": response['data']}
+        resp = {"draft_invoice": response['data']}
         return make_response(resp, response['status'])
     
     except APIServerDefError as e:

--- a/con_opstk/data_handler/update_handler/state_compare.py
+++ b/con_opstk/data_handler/update_handler/state_compare.py
@@ -293,7 +293,7 @@ class BulkUpdateHandler(UpdateHandler):
 
                 billing_acct = self.view.users[user_id_tup].billing_acct_id
                 if billing_acct is not None:
-                    order_id = self.billing_service.create_order(account_id=billing_acct, os_stack_id = os_stack.id)['headers']['Location'].split('/')[-1]
+                    order_id = self.billing_service.create_order(account_id=billing_acct)['headers']['Location'].split('/')[-1]
                     new_rack.order_id = order_id
             except Exception as e:
                 self.__LOGGER.error(f"Failed to create Rack - {type(e).__name__} - {e} - {sys.exc_info()[2].tb_frame.f_code.co_filename} - {sys.exc_info()[2].tb_lineno}")


### PR DESCRIPTION
These don't have anything to do with visualiser's change from integer IDs to UUID IDs.  I think that they were just missed/reverted during the big refactor merge.

The issues that I encountered were:

1. Middleware would fail to create the killbill order/subscription when it detected a new rack due to passing a `os_stack_id` keyword that was no longer expected.
2. The preview draft invoice functionality was broken due to the JSON containing the key `invoice_html` instead of `draft_invoice`.

As far as I can tell the middleware services work just fine with concertim's new UUIDs.

I'm not terribly familiar with the middleware code base so it would be good to have someone pay particular attention to the removal of the `os_stack_id` keyword change.  I know that this is likely to have been affected by the in-progress work on having cluster builder create killbill subscriptions.