### PR TITLE
(for code-abstraction branch) Track IDs of created objects across frontend update runs.

### DIFF
--- a/conser/modules/clients/concertim/objects/view.py
+++ b/conser/modules/clients/concertim/objects/view.py
@@ -150,5 +150,21 @@ class ConcertimView(object):
                 break
         return matching
 
+    def rebuild_indices(self):
+        '''
+        When we create new objects in Concertim, they are given IDs and those IDs
+        are placed in the first entry in the object's ID tuple. However, we don't
+        update the keys of the respective dicts, which a lot of the handler code
+        uses instead of getting the ID from an object itself.
 
+        This method recreates the rack, template and device dicts so that the
+        keys match with the object's IDs again.
+        '''
+        new_racks = { r.id: r for r in self.racks.values() }
+        self.racks = new_racks
 
+        new_templates = { t.id: t for t in self.templates.values() }
+        self.templates = new_templates
+
+        new_devices = { d.id: d for d in self.devices.values() }
+        self.devices = new_devices


### PR DESCRIPTION
When `fe_updates` runs, it finds objects from the view that have no Concertim ID and attempts to create them in Concertim. However, it makes no record of the creation, which means that subsequent runs will use stale data and continue to attempt to create the same objects (every five seconds) until the `view_sync` process runs to update and writes a new view file based on up-to-date Concertim data.

Unless we save the IDs of objects we create in Concertim into the view, `fe_updates` will keep trying (and failing) to create them again until the sync handler runs.

This PR makes `fe_updates` do just that:
- On creation of Concertim objects, update the objects in our view with the new IDs
- At the end of the run, rebuild the indices for the dicts in the view (so that the keys for the dicts match the new IDs for the objects in them)
- After the indices are rebuilt, save and merge the view data so it gets loaded for the next run through the loop

The current logic is that, when it runs, the `view_sync` process will blow away any changes we make to the view file; but that's fine because the new data from the sync handler will contain the IDs we need anyway.

With these changes, `fe_updates` doesn't repeatedly make requests to the Concertim backend that will fail, and throw consequent exceptions, on the second and subsequent runs through its main loop.

The one remaining concern here is when `view_sync` and `fe_updates` runs happen simultaneously - which is fine unless the `fe_updates` finishes _after_ `view_sync`, in which case the new Concertim data from the `view_sync` run will be overwritten by the incomplete data from `fe_updates`. Two possible solutions come to mind:

1. Update the logic of `merge_views` so that `view_sync`'s view always overwrites a view from `fe_updates`, regardless of timestamp;
2. Prevent `sync` from writing a view while `fe_updates` is running.

Or, alternatively, ensure that `sync` and `fe_updates` can't run in parallel by always running the latter immediately after the former in the same process.