### PR TITLE
Obtain cluster name for invoice items & other fixes

### DIFF
--- a/conser/modules/clients/billing/killbill/client.py
+++ b/conser/modules/clients/billing/killbill/client.py
@@ -207,7 +207,7 @@ class KillbillClient(AbsBillingClient):
                     "unitType": METRIC_PREFIX + usage_metric_type,
                     "usageRecords": [
                         {
-                            "recordDate": datetime.today().strftime("%Y-%m-%d") + "T12:00:00Z",
+                            "recordDate": datetime.today().strftime("%Y-%m-%d") + "T23:59:59Z",
                             "amount": amount_to_post,
                         }
                     ],
@@ -832,19 +832,22 @@ class KillbillClient(AbsBillingClient):
                 if subscription_id is not None and item["item_type"] in ["USAGE", "RECURRING"]:
                     if subscription_id not in new_items:
                         custom_fields = self._get_custom_fields('subscription', subscription_id)['data']
-                        found = False
                         openstack_stack_id = None
+                        openstack_stack_name = None
                         for field in custom_fields:
                             if field['name'] == "openstack_stack_id" and len(field['value']) > 0:
-                                found = True
-                                project_cloud_id = field['value']
+                                openstack_stack_id = field['value']
+                            elif field['name'] == "openstack_stack_name" and len(field['value']) > 0:
+                                openstack_stack_name = field['value']
+
+                            if openstack_stack_id and openstack_stack_name:
                                 break
-                        if found is True:
+                        if openstack_stack_id and openstack_stack_name:
                             if subscription_id not in new_items:
                                 new_items[subscription_id] = {
                                     'amount': item['amount'],
                                     'openstack_stack_id': openstack_stack_id,
-                                    'openstack_stack_name': item['product_name'],
+                                    'openstack_stack_name': openstack_stack_name,
                                     'start_date': item['start_date'],
                                     'end_date': item['end_date'],
                                     'currency': item['currency']

--- a/conser/modules/handlers/api_handler/handler.py
+++ b/conser/modules/handlers/api_handler/handler.py
@@ -330,7 +330,7 @@ class APIHandler(Handler):
         return return_dict
 
     def get_draft_invoice(self, project_billing_id):
-        self.__LOGGER.debug(f"Retieving preview of upcoming invoice for {project_billing_id}")
+        self.__LOGGER.debug(f"Retrieving preview of upcoming invoice for {project_billing_id}")
         # EXIT CASES
         if 'billing' not in self.clients or not self.clients['billing']:
             raise EXCP.MissingRequiredClient('billing')

--- a/conser/modules/handlers/billing_handler/handler.py
+++ b/conser/modules/handlers/billing_handler/handler.py
@@ -5,6 +5,7 @@ import conser.exceptions as EXCP
 import conser.utils.common as UTILS
 
 # Py Packages
+import math
 import time
 from datetime import datetime, timedelta
 
@@ -125,7 +126,8 @@ class BillingHandler(AbsBillingHandler):
                 project_billing_id=team_id_tup[2]
             )['amount']
 
-            self.view.teams[team_id_tup].cost = float(team_cost_dict['total_cost'])
+            # Some queries return rounded costs, some not - rounding cost here makes slightly more consistent
+            self.view.teams[team_id_tup].cost = math.ceil(float(team_cost_dict['total_cost']))
             self.view.teams[team_id_tup].credits = float(team_remaining_credits)
             #-- Update team in Concertim
             self.concertim_cost_update(


### PR DESCRIPTION
Linked to https://github.com/alces-flight/concertim-cluster-builder/pull/50

- Obtains and passes the `openstack_stack_name` for relevant invoice items
- fixes typo so `openstack_stack_id` is now correctly included in relevant invoice items
- fixes costs not always being calculated on first billing day