### PR TITLE
Adding amount, balance and credit_adj fields to paginated invoice list

### DIFF
--- a/conser/api/header_auth.py
+++ b/conser/api/header_auth.py
@@ -5,6 +5,7 @@ import time
 
 
 def authenticate_headers(headers, logger):
+
     headers = dict(headers)
     logger.debug(f"Headers : {headers}")
 
@@ -41,3 +42,4 @@ def authenticate_headers(headers, logger):
 
     logger.debug("Authentication Successful")
     return True
+

--- a/conser/modules/clients/billing/killbill/client.py
+++ b/conser/modules/clients/billing/killbill/client.py
@@ -633,22 +633,23 @@ class KillbillClient(AbsBillingClient):
             limit=limit
         )
         resp_dict = self._get_dict_from_resp(resp)
+        
         inv_list = []
         for inv in resp_dict['data']:
-            inv_list.append(inv.to_dict())
 
-        # Populating 'amount', 'balance' and 'credit_adj' to invoice_list output 
-        for inv in inv_list:
-
+            invoice = inv.to_dict()
+                        
+            # Populating 'amount', 'balance' and 'credit_adj' to invoice_list output 
             resp = self.apis['invoice'].get_invoice_with_http_info(
-                inv['invoice_id']
+                invoice['invoice_id']
             )
+            details = self._get_dict_from_resp(resp)['data'].to_dict()
 
-            resp_dict = self._get_dict_from_resp(resp)
+            invoice['amount'] = details['amount']
+            invoice['credit_adj'] = details['credit_adj']
+            invoice['balance'] = details['balance']
 
-            inv['amount'] = resp_dict['data'].to_dict()['amount']
-            inv['credit_adj'] = resp_dict['data'].to_dict()['credit_adj']
-            inv['balance'] = resp_dict['data'].to_dict()['balance']
+            inv_list.append(invoice)
 
 
         # BUILD RETURN DICT


### PR DESCRIPTION
Paginated invoice list response from Killbill shows 'amount', 'balance', and 'credit_adj' as 0. This PR iterates through invoice list for an account, and retrieves individual invoices so as to populate the above three fields.