### PR TITLE
include invoice credit adjustment items

### DIFF
--- a/conser/modules/clients/billing/killbill/client.py
+++ b/conser/modules/clients/billing/killbill/client.py
@@ -880,10 +880,20 @@ class KillbillClient(AbsBillingClient):
                                     'openstack_stack_name': openstack_stack_name,
                                     'start_date': item['start_date'],
                                     'end_date': item['end_date'],
-                                    'currency': item['currency']
+                                    'currency': item['currency'],
+                                    'type': "cost"
                                 }
                     else:
                         new_items[subscription_id]['amount'] += item['amount']
+                elif item["item_type"] == "CBA_ADJ":
+                    new_items[item["invoice_item_id"]] = {
+                        'amount': item['amount'],
+                        'start_date': item['start_date'],
+                        'end_date': item['end_date'],
+                        'currency': item['currency'],
+                        'type': "credits"
+                    }
+
         new_invoice = invoice_data
         new_invoice['items'] = new_items
         return new_invoice


### PR DESCRIPTION
- Killbill invoice items with type `CBA_ADJ` are now included in invoices
- Invoice items are now given a `type` field, of either `cost` or `credits` so visualiser can differentiate