### PR TITLE
Cloud statistics & project quotas

### DIFF
--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -552,6 +552,31 @@ class OpenstackClient(AbsCloudClient):
         # RETURN
         return return_dict
 
+    def get_project_quotas(self, project_id):
+        # EXIT CASES
+        self.__LOGGER.debug(f"Fetching project quotas")
+        if 'nova' not in self.components or not self.components['nova']:
+            raise EXCP.NoComponentFound('nova')
+        if 'cinder' not in self.components or not self.components['cinder']:
+            raise EXCP.NoComponentFound('cinder')
+        if 'neutron' not in self.components or not self.components['neutron']:
+            raise EXCP.NoComponentFound('neutron')
+
+        # CLOUD OBJECT LOGIC
+        quotas = self.components['nova'].get_project_quotas(project_id=project_id).to_dict()
+        cinder_quotas = self.components['cinder'].get_project_quotas(project_id=project_id).to_dict()
+        neutron_quotas = self.components['neutron'].get_project_quotas(project_id=project_id)["quota"]
+
+        quotas.update(cinder_quotas)
+        quotas.update(neutron_quotas)
+        # BUILD RETURN DICT
+        self.__LOGGER.debug(f"Building Return dictionary")
+        return_dict = {
+            'quotas': quotas
+        }
+        # RETURN
+        return return_dict
+
     def get_all_cm_users(self):
         """
         Get all Concertim Managed Users IDs from the cloud.

--- a/conser/modules/clients/cloud/openstack/components/cinder.py
+++ b/conser/modules/clients/cloud/openstack/components/cinder.py
@@ -36,3 +36,10 @@ class CinderComponent(OpstkBaseComponent):
             return self.client.volumes.get(volume_id)
         except NotFound as e:
             raise EXCP.MissingCloudObject(f"{volume_id}")
+
+    def get_project_quotas(self, project_id):
+        try:
+            return self.client.quotas.get(project_id)
+        except Exception as e:
+            self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
+            raise e

--- a/conser/modules/clients/cloud/openstack/components/neutron.py
+++ b/conser/modules/clients/cloud/openstack/components/neutron.py
@@ -31,3 +31,10 @@ class NeutronComponent(OpstkBaseComponent):
 
     def get_network(self, network_id):
         return self.client.show_network(network_id)
+
+    def get_project_quotas(self, project_id):
+        try:
+            return self.client.show_quota(project_id)
+        except Exception as e:
+            self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
+            raise e

--- a/conser/modules/clients/cloud/openstack/components/nova.py
+++ b/conser/modules/clients/cloud/openstack/components/nova.py
@@ -168,6 +168,13 @@ class NovaComponent(OpstkBaseComponent):
             self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
             raise e
 
+    def get_project_quotas(self, project_id):
+        try:
+            return self.client.quotas.get(project_id)
+        except Exception as e:
+            self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
+            raise e
+
     def disconnect(self):
         self.__LOGGER.debug("Disconnecting Nova Component Connection")
         self.client = None

--- a/conser/modules/handlers/api_handler/handler.py
+++ b/conser/modules/handlers/api_handler/handler.py
@@ -504,6 +504,23 @@ class APIHandler(Handler):
         # RETURN
         return return_dict
 
+    def get_account_quotas(self, project_id):
+        self.__LOGGER.debug(f"Fetching account quotas")
+        # EXIT CASES
+        if 'cloud' not in self.clients or not self.clients['cloud']:
+            raise EXCP.MissingRequiredClient('cloud')
+
+        # OBJECT LOGIC
+        quotas = self.clients['cloud'].get_project_quotas(project_id=project_id)['quotas']
+
+        # BUILD RETURN DICT
+        self.__LOGGER.debug(f"Building Return dictionary")
+        return_dict = {
+            'quotas': quotas
+        }
+        # RETURN
+        return return_dict
+
     ##############################
     # HANDLER REQUIRED FUNCTIONS #
     ##############################


### PR DESCRIPTION
Adds two new endpoints:

**`GET /statistics`**

- This makes use of `nova`'s `hypervisor_stats.statistics()` to determine & return the current usage and max possible total vcpus, ram and disk space on openstack, and how many instances are running. E.g. we are using 10 out of 20 possible vcpus

**`GET /team/<team_project_id>/quotas`**

- this determines and returns quotas defined for a team (project), as defined for nova, cinder and neutron. E.g. the max total number of instances or volumes can be present in the project. All available quota values are returned
- Note: The various clients return a quota value of -1 if there is no set limit
- These quotas also don't factor in how much resource is actually available on openstack, e.g. the quota could allow 100 vcpus, but only 10 are actually possible
- this only includes the quota, the actual usage is not calculated here as that will require many different queries to collate the data