### PR TITLE
Limits endpoint

### DIFF
--- a/conser/api/api_server.py
+++ b/conser/api/api_server.py
@@ -296,8 +296,8 @@ def get_team_quotas(team_project_id):
         disconnect_handler(handler)
 
 # This is similar to quotas, but only covers a small number of limits and also includes some usage figures
-def get_team_limits(team_project_id):
-    app.logger.info("Starting - Getting team limits")
+def get_user_team_limits():
+    app.logger.info("Starting - Getting user team limits")
     try:
         # Authenticate with JW
         authenticate(request.headers)
@@ -321,7 +321,8 @@ def get_team_limits(team_project_id):
         )
 
         # Call Function in API Handler
-        handler_return = handler.get_account_limits(project_id=team_project_id)
+        # Project id is determined by session
+        handler_return = handler.get_user_project_limits()
         app.logger.debug(f"Handler Return Data - {handler_return}")
 
         # Return to Concertim
@@ -1104,8 +1105,9 @@ app.add_url_rule('/team/<team_project_id>/quotas', endpoint='get_team_quotas',
                                 view_func=get_team_quotas,
                                 methods=['GET'])
 
-app.add_url_rule('/team/<team_project_id>/limits', endpoint='get_team_limits',
-                                view_func=get_team_limits,
+# Project ID is determined by session - openstack does not permit specifying project unless an admin
+app.add_url_rule('/team/limits', endpoint='get_user_team_limits',
+                                view_func=get_user_team_limits,
                                 methods=['GET'])
 
 #### TEAM ROLES

--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -578,7 +578,7 @@ class OpenstackClient(AbsCloudClient):
         # RETURN
         return return_dict
 
-    def get_project_limits(self, project_id):
+    def get_user_project_limits(self):
         # EXIT CASES
         self.__LOGGER.debug(f"Fetching project limits")
         if 'nova' not in self.components or not self.components['nova']:
@@ -587,8 +587,9 @@ class OpenstackClient(AbsCloudClient):
             raise EXCP.NoComponentFound('cinder')
 
         # CLOUD OBJECT LOGIC
-        limits = self.components['nova'].get_project_limits(project_id)
-        limits.update(self.components['cinder'].get_project_limits(project_id))
+        # Project is determined by session
+        limits = self.components['nova'].get_project_limits()
+        limits.update(self.components['cinder'].get_project_limits())
 
         # BUILD RETURN DICT
         self.__LOGGER.debug(f"Building Return dictionary")

--- a/conser/modules/clients/cloud/openstack/components/cinder.py
+++ b/conser/modules/clients/cloud/openstack/components/cinder.py
@@ -44,10 +44,11 @@ class CinderComponent(OpstkBaseComponent):
             self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
             raise e
 
-    def get_project_limits(self, project_id):
+    # Project determined by session
+    def get_project_limits(self):
         try:
-            self.__LOGGER.debug(f"Getting limits for Project:{project_id}")
-            return self.client.limits.get(tenant_id=project_id).to_dict()["absolute"]
+            self.__LOGGER.debug(f"Getting limits for Project")
+            return self.client.limits.get().to_dict()["absolute"]
         except Exception as e:
             self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
             raise e

--- a/conser/modules/clients/cloud/openstack/components/nova.py
+++ b/conser/modules/clients/cloud/openstack/components/nova.py
@@ -175,10 +175,11 @@ class NovaComponent(OpstkBaseComponent):
             self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
             raise e
 
-    def get_project_limits(self, project_id):
+    # Project is determined by session
+    def get_project_limits(self):
         try:
-            self.__LOGGER.debug(f"Getting limits for Project:{project_id}")
-            return self.client.limits.get(tenant_id=project_id).to_dict()["absolute"]
+            self.__LOGGER.debug(f"Getting limits for Project")
+            return self.client.limits.get().to_dict()["absolute"]
         except Exception as e:
             self.__LOGGER.error(f"An unexpected error : {type(e).__name__} - {e}")
             raise e

--- a/conser/modules/handlers/api_handler/handler.py
+++ b/conser/modules/handlers/api_handler/handler.py
@@ -522,14 +522,14 @@ class APIHandler(Handler):
         return return_dict
 
 
-    def get_account_limits(self, project_id):
+    def get_user_project_limits(self):
         self.__LOGGER.debug(f"Fetching account limits")
         # EXIT CASES
         if 'cloud' not in self.clients or not self.clients['cloud']:
             raise EXCP.MissingRequiredClient('cloud')
 
         # OBJECT LOGIC
-        limits = self.clients['cloud'].get_project_limits(project_id=project_id)['limits']
+        limits = self.clients['cloud'].get_user_project_limits()['limits']
 
         # BUILD RETURN DICT
         self.__LOGGER.debug(f"Building Return dictionary")


### PR DESCRIPTION
Adds an endpoint `/team/team_id/limits` for getting a project's core quotas & usage, by making use of cinder and nova's `get_limits` functionality.

The quotas endpoint `/team/team_id/quotas` remains, as whilst similar, this does not include any usage but does include a much wider range of quotas (which may prove useful in the future).