### PR TITLE
Add deleting of networks and volumes

### DIFF
--- a/conser/api/api_server.py
+++ b/conser/api/api_server.py
@@ -511,14 +511,15 @@ def update_status(obj_type, obj_id):
         verify_required_data(request_data, 
             'cloud_env', 
             'action')
-        
+
+        component = {'racks': 'heat', 'instances': 'nova', 'volumes': 'cinder', 'networks': 'neutron'}[obj_type]
         # Create API Handler
         handler = Factory.get_handler(
             "api", 
             conf_dict,
             log_file,
             cloud_auth_dict=request_data['cloud_env'],
-            cloud_components_list=['nova', 'heat'],
+            cloud_components_list=[component],
             enable_concertim_client=False,
             enable_cloud_client=True,
             enable_billing_client=True
@@ -538,8 +539,7 @@ def update_status(obj_type, obj_id):
         }
         return make_response(resp, 201)
     except Exception as e:
-        raise e
-        # return handle_exception(e)
+        return handle_exception(e)
     finally:
         app.logger.info(f"Finished - Updating status for {obj_type}:{obj_id}")
         disconnect_handler(handler)

--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -1028,7 +1028,6 @@ class OpenstackClient(AbsCloudClient):
             raise EXCP.NoComponentFound('cinder')
         self.__LOGGER.debug(f"Fetching volume {volume_id}")
         volume = self.components['cinder'].get_volume(volume_id)
-        self.__LOGGER.debug(f"{volume.to_dict()}")
         return volume
 
     def get_network_info(self, network_id):

--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -114,12 +114,14 @@ class OpenstackClient(AbsCloudClient):
         self.CONCERTIM_STATE_MAP = {
             'DEVICE':{
                 'ACTIVE': ['active', 'Active', 'ACTIVE', 'running', 'in-use'],
-                'STOPPED': ['stopped', 'available'],
+                'STOPPED': ['stopped'],
+                'AVAILABLE': ['available'],
                 'SUSPENDED': ['suspended'],
                 'IN_PROGRESS': [
                     'building', 'deleting', 'scheduling', 'networking', 'block_device_mapping',
                     'spawning', 'deleted', 'powering-on', 'powering-off', 'suspending',
-                    'creating', 'attaching', 'detaching', 'maintenance', 'reserved'
+                    'creating', 'attaching', 'detaching', 'maintenance', 'reserved',
+                    'downloading'
                 ],
                 'FAILED': []
             },

--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -91,7 +91,9 @@ class OpenstackClient(AbsCloudClient):
         'destroy': 'destroy_volume',
         'detach': 'detach_volume'
     }
-    VALID_NETWORK_ACTIONS = {}
+    VALID_NETWORK_ACTIONS = {
+        'destroy': 'destroy_network'
+    }
     VALID_CLUSTER_ACTIONS = {
         'suspend': 'suspend_stack',
         'resume': 'resume_stack',
@@ -1229,6 +1231,36 @@ class OpenstackClient(AbsCloudClient):
         # CLOUD OBJECT LOGIC
         attempt = getattr(self.components['cinder'], OpenstackClient.VALID_VOLUME_ACTIONS[action])(
             volume_cloud_id
+        )
+
+        # BUILD RETURN DICT
+        self.__LOGGER.debug(f"Building Return dictionary")
+        return_dict = {
+            'submitted': True,
+            'request_ids': attempt.request_ids
+        }
+
+        # RETURN
+        return return_dict
+
+    def update_network_status(self, network_cloud_id, action):
+        """
+        Change status of a network (destroy, etc.)
+        """
+        self.__LOGGER.debug(f"Updating Network {network_cloud_id} with action {action}")
+        # EXIT CASES
+        if 'neutron' not in self.components or not self.components['neutron']:
+            raise EXCP.NoComponentFound('neutron')
+        if not network_cloud_id:
+            raise EXCP.MissingRequiredArgs('network_cloud_id')
+        if not action:
+            raise EXCP.MissingRequiredArgs('action')
+        if action not in OpenstackClient.VALID_NETWORK_ACTIONS:
+            raise EXCP.InvalidArguments(f"action:{action}")
+
+        # CLOUD OBJECT LOGIC
+        attempt = getattr(self.components['neutron'], OpenstackClient.VALID_NETWORK_ACTIONS[action])(
+            network_cloud_id
         )
 
         # BUILD RETURN DICT

--- a/conser/modules/clients/cloud/openstack/client.py
+++ b/conser/modules/clients/cloud/openstack/client.py
@@ -87,6 +87,11 @@ class OpenstackClient(AbsCloudClient):
         'resume': 'resume_instance',
         'destroy': 'destroy_instance'
     }
+    VALID_VOLUME_ACTIONS = {
+        'destroy': 'destroy_volume',
+        'detach': 'detach_volume'
+    }
+    VALID_NETWORK_ACTIONS = {}
     VALID_CLUSTER_ACTIONS = {
         'suspend': 'suspend_stack',
         'resume': 'resume_stack',
@@ -108,10 +113,14 @@ class OpenstackClient(AbsCloudClient):
             self.req_keystone_objs = self.__populate_required_objs('keystone', required_ks_objs)
         self.CONCERTIM_STATE_MAP = {
             'DEVICE':{
-                'ACTIVE': ['active', 'running'],
-                'STOPPED': ['stopped'],
+                'ACTIVE': ['active', 'Active', 'ACTIVE', 'running', 'in-use'],
+                'STOPPED': ['stopped', 'available'],
                 'SUSPENDED': ['suspended'],
-                'IN_PROGRESS': ['building', 'deleting', 'scheduling', 'networking', 'block_device_mapping', 'spawning', 'deleted', 'powering-on', 'powering-off', 'suspending'],
+                'IN_PROGRESS': [
+                    'building', 'deleting', 'scheduling', 'networking', 'block_device_mapping',
+                    'spawning', 'deleted', 'powering-on', 'powering-off', 'suspending',
+                    'creating', 'attaching', 'detaching', 'maintenance', 'reserved'
+                ],
                 'FAILED': []
             },
             'RACK':{
@@ -1015,6 +1024,7 @@ class OpenstackClient(AbsCloudClient):
             raise EXCP.NoComponentFound('cinder')
         self.__LOGGER.debug(f"Fetching volume {volume_id}")
         volume = self.components['cinder'].get_volume(volume_id)
+        self.__LOGGER.debug(f"{volume.to_dict()}")
         return volume
 
     def get_network_info(self, network_id):
@@ -1187,6 +1197,36 @@ class OpenstackClient(AbsCloudClient):
         # CLOUD OBJECT LOGIC
         attempt = getattr(self.components['nova'], OpenstackClient.VALID_SERVER_ACTIONS[action])(
             instance_id=server_cloud_id
+        )
+
+        # BUILD RETURN DICT
+        self.__LOGGER.debug(f"Building Return dictionary")
+        return_dict = {
+            'submitted': True,
+            'request_ids': attempt.request_ids
+        }
+
+        # RETURN
+        return return_dict
+
+    def update_volume_status(self, volume_cloud_id, action):
+        """
+        Change status of a volume (destroy, etc.)
+        """
+        self.__LOGGER.debug(f"Updating Volume {volume_cloud_id} with action {action}")
+        # EXIT CASES
+        if 'cinder' not in self.components or not self.components['cinder']:
+            raise EXCP.NoComponentFound('cinder')
+        if not volume_cloud_id:
+            raise EXCP.MissingRequiredArgs('volume_cloud_id')
+        if not action:
+            raise EXCP.MissingRequiredArgs('action')
+        if action not in OpenstackClient.VALID_VOLUME_ACTIONS:
+            raise EXCP.InvalidArguments(f"action:{action}")
+
+        # CLOUD OBJECT LOGIC
+        attempt = getattr(self.components['cinder'], OpenstackClient.VALID_VOLUME_ACTIONS[action])(
+            volume_cloud_id
         )
 
         # BUILD RETURN DICT

--- a/conser/modules/clients/cloud/openstack/components/cinder.py
+++ b/conser/modules/clients/cloud/openstack/components/cinder.py
@@ -66,6 +66,19 @@ class CinderComponent(OpstkBaseComponent):
         except NotFound as e:
             raise EXCP.MissingCloudObject(f"{volume_id}")
 
+    def detach_volume(self, volume_id):
+        try:
+            return self.client.volumes.detach(volume_id)
+        except NotFound as e:
+            raise EXCP.MissingCloudObject(f"{volume_id}")
+
+    def destroy_volume(self, volume_id):
+        try:
+            # Note: force destroy doesn't actually force deletion in all circumstances
+            return self.client.volumes.force_delete(volume_id)
+        except NotFound as e:
+            raise EXCP.MissingCloudObject(f"{volume_id}")
+
     def get_project_quotas(self, project_id):
         try:
             return self.client.quotas.get(project_id)

--- a/conser/modules/clients/cloud/openstack/components/cinder.py
+++ b/conser/modules/clients/cloud/openstack/components/cinder.py
@@ -74,7 +74,7 @@ class CinderComponent(OpstkBaseComponent):
 
     def destroy_volume(self, volume_id):
         try:
-            # Note: force destroy doesn't actually force deletion in all circumstances
+            # Note: force delete doesn't actually force deletion in all circumstances
             return self.client.volumes.force_delete(volume_id)
         except NotFound as e:
             raise EXCP.MissingCloudObject(f"{volume_id}")

--- a/conser/modules/clients/concertim/objects/device.py
+++ b/conser/modules/clients/concertim/objects/device.py
@@ -31,6 +31,7 @@ class ConcertimDevice(object):
     def __init__(self,
         concertim_id=None,
         cloud_id=None,
+        type=None,
         concertim_name=None,
         cloud_name=None,
         rack_id_tuple=None,
@@ -38,10 +39,11 @@ class ConcertimDevice(object):
         location=None,
         description='',
         status=None,
-        cost=0.0
+        cost=0.0,
     ):
         self.id = tuple((concertim_id, cloud_id))
         self.name = tuple((concertim_name, cloud_name))
+        self.type = type
         self.description = description
         self.rack_id_tuple = rack_id_tuple
         self.template = template
@@ -60,6 +62,7 @@ class ConcertimDevice(object):
             f"<ConcertimDevice:{{ "
                 f"id:{repr(self.id)}, "
                 f"name:{repr(self.name)}, "
+                f"type: {repr(self.type)}, "
                 f"description:{repr(self.description)}, "
                 f"status:{repr(self.status)}, "
                 f"rack_id_tuple:{repr(self.rack_id_tuple)}, "

--- a/conser/modules/clients/concertim/utils/endpoints.py
+++ b/conser/modules/clients/concertim/utils/endpoints.py
@@ -47,6 +47,7 @@ ENDPOINTS = {
                             "template_id": '{template_id}',
                             "device": {
                                 "name": '{name}',
+                                "type": 'Instance',
                                 "description": '{description}',
                                 "status" : "{status}",
                                 "location": {
@@ -78,6 +79,7 @@ ENDPOINTS = {
                             "device": {
                                 "name": '{name}',
                                 "description": '{description}',
+                                "type": 'Network',
                                 "status" : "{status}",
                                 "location": {
                                     "facing": '{facing}',
@@ -106,6 +108,7 @@ ENDPOINTS = {
                             "template_id": '{template_id}',
                             "device": {
                                 "name": '{name}',
+                                "type": 'Volume',
                                 "description": '{description}',
                                 "status" : "{status}",
                                 "location": {

--- a/conser/modules/handlers/api_handler/handler.py
+++ b/conser/modules/handlers/api_handler/handler.py
@@ -37,9 +37,17 @@ class APIHandler(Handler):
     # DEFAULTS #
     ############
     ACTIONS_MAP = {
-        'devices': {
+        'instances': {
             'function': 'update_server_status',
             'actions': ['on', 'off', 'suspend', 'resume', 'destroy']
+        },
+        'volumes': {
+            'function': 'update_volume_status',
+            'actions': ['destroy', 'detach']
+        },
+        'networks': {
+            'function': 'update_network_status',
+            'actions': []
         },
         'racks': {
             'function': 'update_cluster_status',

--- a/conser/modules/handlers/api_handler/handler.py
+++ b/conser/modules/handlers/api_handler/handler.py
@@ -47,7 +47,7 @@ class APIHandler(Handler):
         },
         'networks': {
             'function': 'update_network_status',
-            'actions': []
+            'actions': ['destroy']
         },
         'racks': {
             'function': 'update_cluster_status',

--- a/conser/modules/handlers/billing_handler/handler.py
+++ b/conser/modules/handlers/billing_handler/handler.py
@@ -107,11 +107,11 @@ class BillingHandler(AbsBillingHandler):
             self.__LOGGER.debug(f"Cost changed: from {original_cost} to {self.view.devices[device_id_tup].cost}")
             #-- Push cost to concertim
             device =  self.view.devices[device_id_tup]
-            if device.details['type'] == "Device::ComputeDetails":
+            if device.type == "Instance":
                 type = "compute_device"
-            elif device.details['type'] == "Device::VolumeDetails":
+            elif device.type == "Volume":
                 type = "volume_device"
-            elif device.details['type'] == "Device::NetworkDetails":
+            elif device.type == "Network":
                 type = "network_device"
             self.concertim_cost_update(type, self.view.devices[device_id_tup])
         self.__LOGGER.debug(f"Finished --- Updating cost data from Cloud for all devices")

--- a/conser/modules/handlers/frontend_handler/metrics/handler.py
+++ b/conser/modules/handlers/frontend_handler/metrics/handler.py
@@ -76,7 +76,7 @@ class MetricsHandler(Handler):
                 self.__LOGGER.debug(f"Skipping metrics for device {device_id_tup}")
                 continue
             self.__LOGGER.debug(f"Starting -- Updating metrics for device {device_id_tup}")
-            if device.details['type'] != 'Device::ComputeDetails':
+            if device.type != 'Instance':
                 self.__LOGGER.debug(f"Device is not a server and is unsupported - skipping {device_id_tup}")
                 continue
             metrics = self.clients['cloud'].get_metrics(

--- a/conser/modules/handlers/frontend_handler/updates/handler.py
+++ b/conser/modules/handlers/frontend_handler/updates/handler.py
@@ -129,7 +129,7 @@ class UpdatesHandler(Handler):
                     self.__LOGGER.debug(f"Device not found in Concertim - Cannot create device - waiting for rack to be created first - skipping")
                     continue
                 self.__LOGGER.debug(f"Device not found in Concertim - creating device {device_id_tup}")
-                created_device = self.create_new_device(device) # TODO: investigate why this not working
+                created_device = self.create_new_device(device)
                 device.id = (created_device['id'], device_id_tup[1])
             else:
                 self.__LOGGER.warning(f"Unrecognized device found in view {device}")

--- a/conser/modules/handlers/frontend_handler/updates/handler.py
+++ b/conser/modules/handlers/frontend_handler/updates/handler.py
@@ -129,7 +129,7 @@ class UpdatesHandler(Handler):
                     self.__LOGGER.debug(f"Device not found in Concertim - Cannot create device - waiting for rack to be created first - skipping")
                     continue
                 self.__LOGGER.debug(f"Device not found in Concertim - creating device {device_id_tup}")
-                created_device = self.create_new_device(device)
+                created_device = self.create_new_device(device) # TODO: investigate why this not working
                 device.id = (created_device['id'], device_id_tup[1])
             else:
                 self.__LOGGER.warning(f"Unrecognized device found in view {device}")
@@ -252,7 +252,7 @@ class UpdatesHandler(Handler):
                 "openstack_stack_id": device_obj.rack_id_tuple[1]
             }
             try:
-                if device_obj.details['type'] == 'Device::ComputeDetails':
+                if device_obj.type == 'Instance':
                     self.clients['concertim'].update_compute_device(
                         ID=device_obj.id[0],
                         variables_dict={
@@ -265,7 +265,7 @@ class UpdatesHandler(Handler):
                             "net_interfaces": device_obj.network_interfaces,
                         }
                     )
-                elif device_obj.details['type'] == 'Device::VolumeDetails':
+                elif device_obj.type == 'Volume':
                     self.clients['concertim'].update_volume_device(
                         ID=device_obj.id[0],
                         variables_dict={
@@ -273,7 +273,7 @@ class UpdatesHandler(Handler):
                             **device_obj.details
                         }
                     )
-                elif device_obj.details['type'] == 'Device::NetworkDetails':
+                elif device_obj.type == 'Network':
                     self.clients['concertim'].update_network_device(
                         ID=device_obj.id[0],
                         variables_dict={
@@ -282,7 +282,7 @@ class UpdatesHandler(Handler):
                         }
                     )
                 else:
-                    self.__LOGGER.error(f"Asked to update device of type {device_obj.details['type']} but don't know how")
+                    self.__LOGGER.error(f"Asked to update device of type {device_obj.type} but don't know how")
                 device_obj._updated = False
                 # "But wait! If we fall into the default case above, the device hasn't really been updated!"
                 # That's true, but running the loop more times isn't going to change that. We've logged the problem,
@@ -308,7 +308,7 @@ class UpdatesHandler(Handler):
             "openstack_stack_id": self.view.racks[device_obj.rack_id_tuple].id[1],
         }
         try:
-            if device_obj.details['type'] == 'Device::ComputeDetails':
+            if device_obj.type == 'Instance':
                 return self.clients['concertim'].create_compute_device(
                     variables_dict={
                         **common_vars,
@@ -320,14 +320,14 @@ class UpdatesHandler(Handler):
                         "login_user": device_obj.details.get('login_user'),
                     }
                 )
-            elif device_obj.details['type'] == 'Device::VolumeDetails':
+            elif device_obj.type == 'Volume':
                 return self.clients['concertim'].create_volume_device(
                     variables_dict={
                         **common_vars,
                         **device_obj.details
                     }
                 )
-            elif device_obj.details['type'] == 'Device::NetworkDetails':
+            elif device_obj.type == 'Network':
                 return self.clients['concertim'].create_network_device(
                     variables_dict={
                         **common_vars,

--- a/conser/modules/handlers/view_handler/sync/handler.py
+++ b/conser/modules/handlers/view_handler/sync/handler.py
@@ -645,7 +645,7 @@ class SyncHandler(AbsViewHandler):
         )
         #-- Find spot in rack for new device
         server_location = self._find_empty_slot(
-            device_type='server', 
+            device_type='Instance',
             rack=matching_rack, 
             device_size=server_template.height
         )
@@ -654,6 +654,7 @@ class SyncHandler(AbsViewHandler):
             concertim_id=None, 
             cloud_id=server_dict['id'], 
             concertim_name=server_dict['name'].replace('.','-').replace('_','-'),
+            type='Instance',
             cloud_name=server_dict['name'], 
             rack_id_tuple=matching_rack.id, 
             template=server_template, 
@@ -665,7 +666,6 @@ class SyncHandler(AbsViewHandler):
         new_device.network_interfaces = server_dict['network_interfaces']
 
         new_device.details = {
-            'type': 'Device::ComputeDetails',
             'ssh_key': server_dict['ssh_key_name'],
             'public_ips': server_dict['public_ips'],
             'private_ips': server_dict['private_ips'],
@@ -720,7 +720,7 @@ class SyncHandler(AbsViewHandler):
         self.__LOGGER.debug(f"Finished --- Updated existing ConcertimDevice from cloud data")
 
     def _update_device_from_cloud(self, existing_device, new_resource):
-        if existing_device.details['type'] == 'Device::ComputeDetails':
+        if existing_device.type == 'Instance':
             # Device will have been updated in update_server_device_from_cloud -
             # nothing to do here
             return
@@ -750,11 +750,6 @@ class SyncHandler(AbsViewHandler):
             existing_device._updated = True
         existing_device._delete_marker=False
 
-    TEMPLATE_TAGS_BY_RESOURCE_TYPE = {
-        'Device::NetworkDetails': 'network',
-        'Device::VolumeDetails': 'volume'
-    }
-
     def _create_device_from_cloud(self, resource, cluster_cloud_id):
         rack = self._find_rack_by_cloud_id(cluster_cloud_id)
         if rack:
@@ -769,10 +764,10 @@ class SyncHandler(AbsViewHandler):
                 details = info['details']
                 # below is needed as if part of a resource group, some APIs give the group name instead of device name
                 name = info['name']
-                template = self._find_tagged_template(self.TEMPLATE_TAGS_BY_RESOURCE_TYPE.get(details['type']))
+                template = self._find_tagged_template(info['type'].lower())
                 if template:
                     location = self._find_empty_slot(
-                        device_type=details['type'],
+                        device_type=info['type'],
                         rack=rack,
                         device_size=template.height
                     )
@@ -787,6 +782,7 @@ class SyncHandler(AbsViewHandler):
                         cloud_id=resource.physical_resource_id,
                         concertim_name=name.replace('.','-').replace('_','-'),
                         cloud_name=name,
+                        type=info['type'],
                         rack_id_tuple=rack.id,
                         template=template,
                         location=location,
@@ -815,7 +811,6 @@ class SyncHandler(AbsViewHandler):
             os_data = self.clients['cloud'].get_volume_info(resource.physical_resource_id)
             return {
                 'details': {
-                    'type': 'Device::VolumeDetails',
                     'availability_zone': os_data.availability_zone,
                     'bootable': json.loads(os_data.bootable.lower()),
                     'encrypted': os_data.encrypted,
@@ -823,13 +818,13 @@ class SyncHandler(AbsViewHandler):
                     'volume_type': os_data.volume_type
                 },
                 'name': os_data.name,
-                'status': os_data.status
+                'status': os_data.status,
+                'type': 'Volume'
             }
         elif resource.resource_type == 'OS::Neutron::Net':
             os_net_data = self.clients['cloud'].get_network_info(resource.physical_resource_id)
             return {
                 'details': {
-                    'type': 'Device::NetworkDetails',
                     'admin_state_up': os_net_data.get('admin_state_up', False),
                     'l2_adjacency': os_net_data.get('l2_adjacency', False),
                     'mtu': os_net_data.get('mtu'),
@@ -837,7 +832,8 @@ class SyncHandler(AbsViewHandler):
                     'port_security_enabled': os_net_data.get('port_security_enabled', False)
                 },
                 'name': os_net_data['name'],
-                'status': os_net_data['status']
+                'status': os_net_data['status'],
+                'type': 'Network'
             }
 
     def _find_tagged_template(self, tag):
@@ -934,7 +930,8 @@ class SyncHandler(AbsViewHandler):
             new_device = ConcertimDevice(
                 concertim_id=con_device['id'], 
                 cloud_id=device_cloud_id, 
-                concertim_name=con_device['name'], 
+                concertim_name=con_device['name'],
+                type=con_device['type'],
                 cloud_name=con_device['name'], 
                 rack_id_tuple=tuple((rack_concertim_id, rack_cloud_id, None)), 
                 template=device_template, 
@@ -949,27 +946,24 @@ class SyncHandler(AbsViewHandler):
             else:
                 # Legacy (pre-1.2) Concertim API doesn't have the `details`
                 # object, and instead has the attributes inlined;
-                if con_device['type'] == 'Device::ComputeDetails':
+                if con_device['type'] == 'Instance':
                     new_device.details = {
-                        'type': 'Device::ComputeDetails',
                         'ssh_key': con_device.get('ssh_key', ''),
                         'volume_details': con_device.get('volume_details', []),
                         'public_ips': con_device.get('public_ips', ''),
                         'private_ips': con_device.get('private_ips', ''),
                         'login_user': con_device.get('login_user', '')
                     }
-                elif con_device['type'] == 'Device::VolumeDetails':
+                elif con_device['type'] == 'Volume':
                     new_device.details = {
-                        'type': 'Device::VolumeDetails',
                         "availability_zone": con_device.get('availability_zone', ''),
                         "bootable": con_device.get('bootable', ''),
                         "encrypted": con_device.get('encrypted', ''),
                         "size":  con_device.get('size', ''),
                         "volume_type": con_device.get('volume_type', '')
                     }
-                elif con_device['type'] == 'Device::NetworkDetails':
+                elif con_device['type'] == 'Network':
                     new_device.details = {
-                        'type': 'Device::NetworkDetails',
                         'admin_state_up': con_device.get('admin_state_up', False),
                         'l2_adjacency': con_device.get('l2_adjacency', False),
                         'mtu': con_device.get('mtu'),
@@ -1027,9 +1021,9 @@ class SyncHandler(AbsViewHandler):
                 self.__LOGGER.error(f"No space found in Rack[ID:{rack.id}] for {device_type} of size '{device_size}'")
                 return None
 
-        if device_type in ['server', 'Device::VolumeDetails']:
+        if device_type in ['Instance', 'Volume']:
             return from_bottom()
-        elif device_type in ['Device::NetworkDetails']:
+        elif device_type in ['Network']:
             return from_top()
         else:
             raise EXCP.InvalidArguments(f"device_type:{device_type}")

--- a/conser/modules/handlers/view_handler/sync/handler.py
+++ b/conser/modules/handlers/view_handler/sync/handler.py
@@ -741,8 +741,8 @@ class SyncHandler(AbsViewHandler):
             existing_device._updated = True
 
         new_status = 'FAILED'
-        for concertim_status, os_statuses in self.clients['cloud'].CONCERTIM_STATE_MAP['RACK'].items():
-            if new_resource.resource_status in os_statuses:
+        for concertim_status, os_statuses in self.clients['cloud'].CONCERTIM_STATE_MAP['DEVICE'].items():
+            if new_info and new_info['status'] in os_statuses:
                 new_status = concertim_status
         if new_status != existing_device.status:
             self.__LOGGER.debug(f"Status has changed from {existing_device.status} to {new_status}")
@@ -778,8 +778,8 @@ class SyncHandler(AbsViewHandler):
                     )
 
                     status = 'FAILED'
-                    for concertim_status, os_statuses in self.clients['cloud'].CONCERTIM_STATE_MAP['RACK'].items():
-                        if resource.resource_status in os_statuses:
+                    for concertim_status, os_statuses in self.clients['cloud'].CONCERTIM_STATE_MAP['DEVICE'].items():
+                        if info['status'] in os_statuses:
                             status = concertim_status
 
                     new_device = ConcertimDevice(
@@ -822,7 +822,8 @@ class SyncHandler(AbsViewHandler):
                     'size': os_data.size,
                     'volume_type': os_data.volume_type
                 },
-                'name': os_data.name
+                'name': os_data.name,
+                'status': os_data.status
             }
         elif resource.resource_type == 'OS::Neutron::Net':
             os_net_data = self.clients['cloud'].get_network_info(resource.physical_resource_id)
@@ -835,7 +836,8 @@ class SyncHandler(AbsViewHandler):
                     'shared': os_net_data.get('shared', False),
                     'port_security_enabled': os_net_data.get('port_security_enabled', False)
                 },
-                'name': os_net_data['name']
+                'name': os_net_data['name'],
+                'status': os_net_data['status']
             }
 
     def _find_tagged_template(self, tag):


### PR DESCRIPTION
Linked to https://github.com/openflighthpc/concertim-ct-visualisation-app/pull/216

- Updates the update status request logic to allow for changes to Volumes and Networks
- Volumes can now be detached from their instance, and deleted
- Volume deletion makes use of `force_delete` which allows for deletion when in an error deleting state. This should help resolve issues seen regularly during testing, where a rack is left unable to be deleted because volume deletion failed. But despite its name, `force_delete` does not actually force deletion generally (e.g. if still attached to a volume, force deletion will still fail)
- Networks can now be deleted. This involves removing/deleting the networks ports first, as openstack forbids deleting a network whilst these are still present
- updates visualiser sync logic to make use of devices now having a type (Instance, Volume or Network)
- also fixes a bug during the visualiser update process, if a network has been destroyed
- also updates status mappings to reflect more possible openstack statuses